### PR TITLE
Push to control plane catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,21 @@ workflows:
       - architect/push-to-app-catalog:
           context: architect
           executor: app-build-suite
-          name: package-and-push-chart
-          app_catalog: giantswarm-playground-catalog
-          app_catalog_test: giantswarm-playground-test-catalog
-          chart: "edgedb"
+          name: push-edgedb-app-to-control-plane-catalog
+          app_catalog: control-plane-catalog
+          app_catalog_test: control-plane-test-catalog
+          chart: edgedb
+          filters:
+            tags:
+              only: /^v.*/
+    
+      - architect/push-to-app-catalog:
+          context: architect
+          executor: app-build-suite
+          name: push-edgedb-app-to-giantswarm-catalog
+          app_catalog: giantswarm-catalog
+          app_catalog_test: giantswarm-test-catalog
+          chart: edgedb
           # Trigger job on git tag.
           filters:
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create initial chart.
 - Add TLS for EdgeDB.
 
+### Changed
+
+- Push to control-plane and giantswarm catalogs. Do not push to playground.
+
 [Unreleased]: https://github.com/giantswarm/edgedb/tree/main


### PR DESCRIPTION
This PR:

- pushes the chart to the control plane catalog
- pushes to the giantswarm catalog instead of the playground

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
