### PR TITLE
Add VPA and CNPG cluster and push to ops catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,3 +15,14 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+
+      - architect/push-to-app-catalog:
+          context: architect
+          executor: app-build-suite
+          name: push-edgedb-app-to-ops-catalog
+          app_catalog: giantswarm-operations-platform-catalog
+          app_catalog_test: giantswarm-operations-platform-test-catalog
+          chart: edgedb
+          filters:
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create initial chart.
 - Add TLS for EdgeDB.
+- Optionally deploy CNPG postgres cluster resource.
 
 ### Changed
 

--- a/helm/edgedb/templates/pg-cluster.yaml
+++ b/helm/edgedb/templates/pg-cluster.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.postgres.cnpg.enabled -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "edgedb.fullname" . }}-postgres
+  namespace: {{ include "resource.default.namespace"  . }}
+spec:
+  instances: {{ .Values.postgres.cnpg.instances }}
+
+  storage:
+    size: {{ .Values.postgres.cnpg.storage.size }}
+{{- end -}}

--- a/helm/edgedb/templates/vpa.yaml
+++ b/helm/edgedb/templates/vpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" -}}
+{{- if .Values.vpa.enabled -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "edgedb.fullname" . }}
+  namespace: {{ include "resource.default.namespace" . }}
+  labels:
+    {{- include "edgedb.labels" . | nindent 4 }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ .Chart.Name }}
+    {{- if .Values.vpa.containerPolicies }}
+      {{- with .Values.vpa.containerPolicies -}}
+        {{ tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+    {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "edgedb.fullname" . }}
+  updatePolicy:
+    updateMode: Auto
+{{- end -}}
+{{- end -}}

--- a/helm/edgedb/values.yaml
+++ b/helm/edgedb/values.yaml
@@ -29,6 +29,13 @@ edgedb:
     serverPassword:
       secretName: edgedb-server-password
 
+postgres:
+  cnpg:
+    enabled: true
+    instances: 2
+    storage:
+      size: 1Gi
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -77,12 +84,20 @@ resources:
     cpu: 250m
     memory: 1024Mi
 
+# Use either HPA or VPA, but not both.
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+# Use either HPA or VPA, but not both.
+vpa:
+  enabled: true
+  containerPolicies:
+    minAllowed:
+      memory: "1024Mi"  # edgedb has a 1GB minimum.
 
 nodeSelector: {}
 


### PR DESCRIPTION
This PR:

- adds a VPA config
- adds a gated cloudnative-pg cluster CR
- pushes the chart to the operations catalog

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
