### PR TITLE
Monitoring, resource, and auth adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Pin minimum CPU to 250m.
+- Deploy pod monitors for the postgres cluster.
+
 ## [0.0.1] - 2024-04-19
 
 ### Added

--- a/helm/edgedb/templates/pg-cluster.yaml
+++ b/helm/edgedb/templates/pg-cluster.yaml
@@ -9,4 +9,13 @@ spec:
 
   storage:
     size: {{ .Values.postgres.cnpg.storage.size }}
+
+  monitoring:
+    enablePodMonitor: {{ .Values.postgres.cnpg.monitoring.podMonitor.enabled }}
+    podMonitorAdditionalLabels:
+    {{- with .Values.postgres.cnpg.monitoring.podMonitor.labels }}
+    {{- toYaml . | nindent 6 }}
+    {{- end}}
+
+  enableSuperuserAccess: true
 {{- end -}}

--- a/helm/edgedb/values.yaml
+++ b/helm/edgedb/values.yaml
@@ -18,7 +18,7 @@ edgedb:
   args:
     - "--enable-backend-adaptive-ha"
   backend:
-    secretName: edgedb-postgres-app
+    secretName: edgedb-postgres-superuser
   container:
     port: 5656
   security:
@@ -35,6 +35,10 @@ postgres:
     instances: 2
     storage:
       size: 1Gi
+    monitoring:
+      podMonitor:
+        enabled: true
+        labels: {}
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -97,6 +101,7 @@ vpa:
   enabled: true
   containerPolicies:
     minAllowed:
+      cpu: "250m"
       memory: "1024Mi"  # edgedb has a 1GB minimum.
 
 nodeSelector: {}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30093

This PR:

- enables pod monitors for the cnpg cluster
- enables the postgres superuser. Unfortunately, edgedb seems to need it
- pins the cpu minimum to prevent VPA from downscaling edgedb too hard

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
