### PR TITLE
Use ImageCatalog, set faster shutdown delays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pin minimum CPU to 250m.
 - Deploy pod monitors for the postgres cluster.
+- Reduce shutdown delays.
+- Use Giant Swarm retagged images.
 
 ## [0.0.1] - 2024-04-19
 

--- a/helm/edgedb/templates/pg-cluster.yaml
+++ b/helm/edgedb/templates/pg-cluster.yaml
@@ -17,5 +17,16 @@ spec:
     {{- toYaml . | nindent 6 }}
     {{- end}}
 
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ImageCatalog
+    major: {{ .Values.postgres.cnpg.imageCatalogRef.major }}
+    name: {{ .Values.postgres.cnpg.imageCatalogRef.name }}
+  
+  # Shutdown behavior is optimized for fast recovery time, at the expense of potential data loss.
+  smartShutdownTimeout: 180
+  stopDelay: 300
+  switchoverDelay: {{ .Values.postgres.cnpg.switchoverDelay }}
+  
   enableSuperuserAccess: true
 {{- end -}}

--- a/helm/edgedb/templates/pg-cluster.yaml
+++ b/helm/edgedb/templates/pg-cluster.yaml
@@ -19,7 +19,7 @@ spec:
 
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
-    kind: ImageCatalog
+    kind: ClusterImageCatalog
     major: {{ .Values.postgres.cnpg.imageCatalogRef.major }}
     name: {{ .Values.postgres.cnpg.imageCatalogRef.name }}
   

--- a/helm/edgedb/values.yaml
+++ b/helm/edgedb/values.yaml
@@ -39,6 +39,12 @@ postgres:
       podMonitor:
         enabled: true
         labels: {}
+    imageCatalogRef:
+      apiGroup: postgresql.cnpg.io
+      kind: ImageCatalog
+      major: 16
+      name: gs-postgresql
+    switchoverDelay: 60
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/helm/edgedb/values.yaml
+++ b/helm/edgedb/values.yaml
@@ -40,8 +40,6 @@ postgres:
         enabled: true
         labels: {}
     imageCatalogRef:
-      apiGroup: postgresql.cnpg.io
-      kind: ImageCatalog
       major: 16
       name: gs-postgresql
     switchoverDelay: 60


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30093

This PR:

- uses an ImageCatalog to use GS-retagged images
- lowers the normal and failover case shutdown delays. This makes the postgres cluster fail over faster, but will potentially lose data. We aren't currently concerned about that, because this database is understood to contain ephemeral data which will be re-created from the cluster state.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
