### PR TITLE
Fix service monitor for scraping metrics

### DIFF
--- a/helm/edgedb/templates/cert.yaml
+++ b/helm/edgedb/templates/cert.yaml
@@ -17,6 +17,7 @@ spec:
     - '*.{{ include "edgedb.fullname" . }}.{{ include "resource.default.namespace"  . }}.svc'
     - '*.{{ include "edgedb.fullname" . }}.{{ include "resource.default.namespace"  . }}'
     - '*.{{ include "edgedb.fullname" . }}'
+    - '{{ include "edgedb.fullname" . }}'
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/helm/edgedb/templates/deployment.yaml
+++ b/helm/edgedb/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.edgedb.security.tls.enabled }}
           volumeMounts:
-            - name: edgedb-tls
+            - name: {{ .Values.edgedb.security.tls.secretName }}
               mountPath: /etc/edgedb/tls
               readOnly: true
           {{- end }}

--- a/helm/edgedb/templates/deployment.yaml
+++ b/helm/edgedb/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
               value: "postgresql://$(PG_USER):$(PG_PASSWORD)@$(PG_SVC)?sslmode=disable"
           ports:
             - containerPort: {{ .Values.edgedb.container.port }}
+              name: {{ .Values.edgedb.container.portName }}
           startupProbe:
             httpGet:
               path: /server/status/alive

--- a/helm/edgedb/templates/pg-cluster.yaml
+++ b/helm/edgedb/templates/pg-cluster.yaml
@@ -24,8 +24,8 @@ spec:
     name: {{ .Values.postgres.cnpg.imageCatalogRef.name }}
   
   # Shutdown behavior is optimized for fast recovery time, at the expense of potential data loss.
-  smartShutdownTimeout: 180
-  stopDelay: 300
+  smartShutdownTimeout: 30
+  stopDelay: 60
   switchoverDelay: {{ .Values.postgres.cnpg.switchoverDelay }}
   
   enableSuperuserAccess: true

--- a/helm/edgedb/templates/service-monitor.yaml
+++ b/helm/edgedb/templates/service-monitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: {{ .Values.edgedb.container.portName | quote }}
+      targetPort: {{ .Values.service.port }}
       {{- if .Values.monitoring.serviceMonitor.interval}}
       interval: {{ .Values.monitoring.serviceMonitor.interval }}
       {{- end }}

--- a/helm/edgedb/templates/service-monitor.yaml
+++ b/helm/edgedb/templates/service-monitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: {{ .Values.service.port }}
+      port: {{ .Values.container.portName | quote }}
       {{- if .Values.monitoring.serviceMonitor.interval}}
       interval: {{ .Values.monitoring.serviceMonitor.interval }}
       {{- end }}

--- a/helm/edgedb/templates/service-monitor.yaml
+++ b/helm/edgedb/templates/service-monitor.yaml
@@ -27,6 +27,7 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      scheme: https
       tlsConfig:
         ca:
           secret:

--- a/helm/edgedb/templates/service-monitor.yaml
+++ b/helm/edgedb/templates/service-monitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: {{ .Values.container.portName | quote }}
+      port: {{ .Values.edgedb.container.portName | quote }}
       {{- if .Values.monitoring.serviceMonitor.interval}}
       interval: {{ .Values.monitoring.serviceMonitor.interval }}
       {{- end }}

--- a/helm/edgedb/templates/service-monitor.yaml
+++ b/helm/edgedb/templates/service-monitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: {{ .Values.service.port | quote}}
+      port: {{ .Values.service.port }}
       {{- if .Values.monitoring.serviceMonitor.interval}}
       interval: {{ .Values.monitoring.serviceMonitor.interval }}
       {{- end }}

--- a/helm/edgedb/templates/service-monitor.yaml
+++ b/helm/edgedb/templates/service-monitor.yaml
@@ -39,6 +39,7 @@ spec:
         keySecret:
           key: tls.key
           name: {{ .Values.edgedb.security.tls.secretName }}
+        serverName: {{ include "edgedb.fullname" . }}
   selector:
     matchLabels:
   {{- include "edgedb.selectorLabels" . | nindent 6 }}

--- a/helm/edgedb/templates/service-monitor.yaml
+++ b/helm/edgedb/templates/service-monitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      targetPort: {{ .Values.service.port }}
+      port: {{ .Values.edgedb.container.portName | quote }}
       {{- if .Values.monitoring.serviceMonitor.interval}}
       interval: {{ .Values.monitoring.serviceMonitor.interval }}
       {{- end }}

--- a/helm/edgedb/templates/service-monitor.yaml
+++ b/helm/edgedb/templates/service-monitor.yaml
@@ -27,6 +27,18 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      tlsConfig:
+        ca:
+          secret:
+            key: ca.crt
+            name: {{ .Values.edgedb.security.tls.secretName }}
+        cert:
+          secret:
+            key: tls.crt
+            name: {{ .Values.edgedb.security.tls.secretName }}
+        keySecret:
+          key: tls.key
+          name: {{ .Values.edgedb.security.tls.secretName }}
   selector:
     matchLabels:
   {{- include "edgedb.selectorLabels" . | nindent 6 }}

--- a/helm/edgedb/templates/service.yaml
+++ b/helm/edgedb/templates/service.yaml
@@ -9,5 +9,6 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
+      name: {{ .Values.service.portName | quote }}
   selector:
     {{- include "edgedb.selectorLabels" . | nindent 4 }}

--- a/helm/edgedb/values.yaml
+++ b/helm/edgedb/values.yaml
@@ -21,6 +21,7 @@ edgedb:
     secretName: edgedb-postgres-superuser
   container:
     port: 5656
+    portName: edgedb
   security:
     tls:
       enabled: true

--- a/helm/edgedb/values.yaml
+++ b/helm/edgedb/values.yaml
@@ -20,8 +20,8 @@ edgedb:
   backend:
     secretName: edgedb-postgres-superuser
   container:
-    port: 5656
-    portName: edgedb
+    port: &containerPort 5656
+    portName: &containerPortName edgedb
   security:
     tls:
       enabled: true
@@ -80,7 +80,8 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 5656
+  port: *containerPort
+  portName: *containerPortName
 
 networkPolicy:
   enabled: true


### PR DESCRIPTION
Debugging this was miserable

Related: https://github.com/prometheus-operator/prometheus-operator/issues/2515

This PR:

- uses the container port name in the service monitor
- wires up TLS for scraping

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
