### PR TITLE
Simplify network policy for database pods

### DIFF
--- a/helm/edgedb/templates/cilium-network-policy.yaml
+++ b/helm/edgedb/templates/cilium-network-policy.yaml
@@ -42,15 +42,11 @@ spec:
       cnpg.io/cluster: {{ include "edgedb.pgClusterName" . }}
       cnpg.io/podRole: instance
   ingress:
-    # Allow ingress to the EdgeDB Postgres cluster from an EdgeDB application pod in the same namespace.
     - fromEndpoints:
+        # Allow ingress to the EdgeDB PostgreSQL cluster from an EdgeDB application pod in the same namespace.
         - matchLabels:
             {{- include "edgedb.selectorLabels" . | nindent 12 }}
-      toPorts:
-        - ports:
-            - port: "5432"
-    # Allow ingress from other CNPG cluster members (including join pods).
-    - fromEndpoints:
+        # Allow ingress from other CNPG cluster members (including join pods).
         - matchLabels:
             cnpg.io/cluster: {{ include "edgedb.pgClusterName" . }}
       toPorts:


### PR DESCRIPTION
This PR:

- slightly simplifies the CiliumNetworkPolicy deployed for edgedb's postgres cluster pods.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
