### PR TITLE
Observability improvements: new podmonitor, cnp, and podlogs resources for gel and database pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `io.giantswarm.application.audience` and `io.giantswarm.application.managed` chart annotations for Backstage visibility.
+- Disable deprecated CNPG operator-managed `PodMonitor` in favor of a new chart-managed `PodMonitor`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `io.giantswarm.application.audience` and `io.giantswarm.application.managed` chart annotations for Backstage visibility.
-- Disable deprecated CNPG operator-managed `PodMonitor` in favor of a new chart-managed `PodMonitor`.
+- Add `PodLogs` resources for Gel and its CNPG database pods.
 
 ### Changed
 
 - Migrate chart metadata annotations to OCI-compatible format.
+- Disable deprecated CNPG operator-managed `PodMonitor` in favor of a new chart-managed `PodMonitor`.
 
 ## [1.0.1] - 2025-12-05
 

--- a/helm/gel/templates/cilium-network-policy.yaml
+++ b/helm/gel/templates/cilium-network-policy.yaml
@@ -19,6 +19,24 @@ spec:
       toPorts:
       - ports:
         - port: "5432"
+    # Allow egress to DNS pods.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: coredns
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: k8s-dns-node-cache
+      toPorts:
+        - ports:
+            - port: "1053"
+              protocol: UDP
+            - port: "1053"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
   ingress:
   - fromEntities:
     - cluster

--- a/helm/gel/templates/networkpolicy.yaml
+++ b/helm/gel/templates/networkpolicy.yaml
@@ -15,7 +15,23 @@ spec:
     - port: 5656
       protocol: TCP
   egress:
-  - {}
+  - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+    toPorts:
+      - ports:
+          - port: "1053"
+            protocol: UDP
+          - port: "1053"
+            protocol: TCP
+          - port: "53"
+            protocol: UDP
+          - port: "53"
+            protocol: TCP
   policyTypes:
   - Egress
   - Ingress

--- a/helm/gel/templates/networkpolicy.yaml
+++ b/helm/gel/templates/networkpolicy.yaml
@@ -15,23 +15,7 @@ spec:
     - port: 5656
       protocol: TCP
   egress:
-  - toEndpoints:
-      - matchLabels:
-          io.kubernetes.pod.namespace: kube-system
-          k8s-app: coredns
-      - matchLabels:
-          io.kubernetes.pod.namespace: kube-system
-          k8s-app: k8s-dns-node-cache
-    toPorts:
-      - ports:
-          - port: "1053"
-            protocol: UDP
-          - port: "1053"
-            protocol: TCP
-          - port: "53"
-            protocol: UDP
-          - port: "53"
-            protocol: TCP
+  - {}
   policyTypes:
   - Egress
   - Ingress

--- a/helm/gel/templates/pg-cluster.yaml
+++ b/helm/gel/templates/pg-cluster.yaml
@@ -10,13 +10,6 @@ spec:
   storage:
     size: {{ .Values.postgres.cnpg.storage.size }}
 
-  monitoring:
-    enablePodMonitor: {{ .Values.postgres.cnpg.monitoring.podMonitor.enabled }}
-    podMonitorAdditionalLabels:
-    {{- with .Values.postgres.cnpg.monitoring.podMonitor.labels }}
-    {{- toYaml . | nindent 6 }}
-    {{- end}}
-
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/helm/gel/templates/pg-pod-monitor.yaml
+++ b/helm/gel/templates/pg-pod-monitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.postgres.cnpg.enabled .Values.postgres.cnpg.monitoring.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "gel.pgClusterName" . }}
+  namespace: {{ include "resource.default.namespace" . }}
+  labels:
+    {{- include "gel.labels" . | nindent 4 }}
+    cnpg.io/cluster: {{ include "gel.pgClusterName" . }}
+    {{- with .Values.postgres.cnpg.monitoring.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "gel.pgClusterName" . }}
+      cnpg.io/podRole: instance
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+{{- end -}}

--- a/helm/gel/templates/podlogs.yaml
+++ b/helm/gel/templates/podlogs.yaml
@@ -1,0 +1,64 @@
+{{- with (.Values.monitoring).podLogs }}
+{{- if and .enabled ($.Capabilities.APIVersions.Has "monitoring.grafana.com/v1alpha2") }}
+apiVersion: monitoring.grafana.com/v1alpha2
+kind: PodLogs
+metadata:
+  name: {{ include "gel.fullname" $ }}
+  namespace: {{ include "resource.default.namespace" $ }}
+  labels:
+    {{- include "gel.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "resource.default.namespace" $ }}
+  selector:
+    matchLabels:
+      {{- include "gel.selectorLabels" $ | nindent 6 }}
+  relabelings:
+    - action: replace
+      replacement: {{ .tenant | quote }}
+      targetLabel: giantswarm_observability_tenant
+    {{- with .relabelings }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if $.Values.postgres.cnpg.enabled }}
+---
+apiVersion: monitoring.grafana.com/v1alpha2
+kind: PodLogs
+metadata:
+  name: {{ include "gel.pgClusterName" $ }}
+  namespace: {{ include "resource.default.namespace" $ }}
+  labels:
+    {{- include "gel.labels" $ | nindent 4 }}
+    cnpg.io/cluster: {{ include "gel.pgClusterName" $ }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "resource.default.namespace" $ }}
+  selector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "gel.pgClusterName" $ }}
+  relabelings:
+    - action: replace
+      replacement: {{ .tenant | quote }}
+      targetLabel: giantswarm_observability_tenant
+    {{- with .relabelings }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/gel/values.yaml
+++ b/helm/gel/values.yaml
@@ -57,6 +57,12 @@ serviceAccount:
 monitoring:
   serviceMonitor:
     enabled: true
+  podLogs:
+    enabled: true
+    tenant: giantswarm
+    labels: {}
+    annotations: {}
+    relabelings: []
 
 podAnnotations: {}
 


### PR DESCRIPTION
This PR:

- replaces the CNPG-managed podmonitor for the database pods with a new one included in this chart. CNPG is removing the managed podmonitor feature.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
